### PR TITLE
Normative: throw on negative set sizes

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -292,7 +292,7 @@ markEffects: true
     1. NOTE: If _rawSize_ is *undefined*, then _numSize_ will be *NaN*.
     1. If _numSize_ is *NaN*, throw a *TypeError* exception.
     1. Let _intSize_ be ! ToIntegerOrInfinity(_numSize_).
-    1. If _intSize_ < 0, set _intSize_ to 0.
+    1. If _intSize_ < 0, throw a *RangeError* exception.
     1. Let _has_ be ? Get(_obj_, *"has"*).
     1. If IsCallable(_has_) is *false*, throw a *TypeError* exception.
     1. Let _keys_ be ? Get(_obj_, *"keys"*).

--- a/spec/index.html
+++ b/spec/index.html
@@ -292,6 +292,7 @@ markEffects: true
     1. NOTE: If _rawSize_ is *undefined*, then _numSize_ will be *NaN*.
     1. If _numSize_ is *NaN*, throw a *TypeError* exception.
     1. Let _intSize_ be ! ToIntegerOrInfinity(_numSize_).
+    1. If _intSize_ < 0, set _intSize_ to 0.
     1. Let _has_ be ? Get(_obj_, *"has"*).
     1. If IsCallable(_has_) is *false*, throw a *TypeError* exception.
     1. Let _keys_ be ? Get(_obj_, *"keys"*).


### PR DESCRIPTION
Fixes https://github.com/tc39/proposal-set-methods/issues/84.

This is observable - for example, previously `(new Set).isSubsetOf({ has(){}, keys(){}, size: -1 })` would have reported `false`, and now it reports `true`. We could alternatively relax the definition of `[[Size]]`. But this seems a little more natural, since we're coercing sizes to integers already.

I would also be fine with throwing for negative reported sizes, since we already throw for NaN.