### PR TITLE
Normative: remove IsCallable check in GetKeysIterator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "Fair",
       "devDependencies": {
-        "@tc39/ecma262-biblio": "^2.1.2407",
-        "ecmarkup": "^15.0.0"
+        "@tc39/ecma262-biblio": "2.1.2599",
+        "ecmarkup": "^17.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -181,9 +181,9 @@
       }
     },
     "node_modules/@tc39/ecma262-biblio": {
-      "version": "2.1.2407",
-      "resolved": "https://registry.npmjs.org/@tc39/ecma262-biblio/-/ecma262-biblio-2.1.2407.tgz",
-      "integrity": "sha512-1kHK+gKo399tKW88+n3D/mbdMGlGvaxgedUubpCihC35n6F1dwkZC7py6FhwawbFatwcychS7q+GRH42IsYy8w==",
+      "version": "2.1.2599",
+      "resolved": "https://registry.npmjs.org/@tc39/ecma262-biblio/-/ecma262-biblio-2.1.2599.tgz",
+      "integrity": "sha512-e/keyo3Z4SlTQZWoJ9Hn+fduloQLkh5rZHeuN6EDpa+99uODys6QzTXPj5XnkFIhFuor2MHoI2+gCXlLHpfLaw==",
       "dev": true
     },
     "node_modules/@tootallnate/once": {
@@ -586,25 +586,25 @@
       }
     },
     "node_modules/ecmarkdown": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-7.2.0.tgz",
-      "integrity": "sha512-p0C4SJCvnvtm0y9gPhXBb5DlNbHsNS44ihVKBw3MXviZG2QQpZNH4z/3PbkpgECOjKOeZI+m84ISHVV9WLECFQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-8.1.0.tgz",
+      "integrity": "sha512-dx6cM6RFjzAXkWr2KQRikED4gy70NFQ0vTI4XUQM/LWcjUYRJUbGdd7nd++trXi5az1JSe49TeeCIVMKDXOtcQ==",
       "dev": true,
       "dependencies": {
         "escape-html": "^1.0.1"
       }
     },
     "node_modules/ecmarkup": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-15.0.0.tgz",
-      "integrity": "sha512-gKmfqwRqw1uNPwkftEOpVIH3VVV0O99IL2cRmnrBduvTE2szOvDytOk74dIOaAwqmhx/lonQuRZ64G7R2ZCUDQ==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-17.0.2.tgz",
+      "integrity": "sha512-+vvA1tI9sISgCKtnfwdC6dcuLGX4DGHPVy9zPh3XJLHeRxxy8euG1vklMM7gsEb6/J4H0ks2yup5Y/ekU51k6g==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",
         "command-line-usage": "^6.1.1",
         "dedent-js": "^1.0.1",
-        "ecmarkdown": "^7.2.0",
+        "ecmarkdown": "^8.1.0",
         "eslint-formatter-codeframe": "^7.32.1",
         "fast-glob": "^3.2.7",
         "grammarkdown": "^3.2.0",
@@ -1645,9 +1645,9 @@
       }
     },
     "@tc39/ecma262-biblio": {
-      "version": "2.1.2407",
-      "resolved": "https://registry.npmjs.org/@tc39/ecma262-biblio/-/ecma262-biblio-2.1.2407.tgz",
-      "integrity": "sha512-1kHK+gKo399tKW88+n3D/mbdMGlGvaxgedUubpCihC35n6F1dwkZC7py6FhwawbFatwcychS7q+GRH42IsYy8w==",
+      "version": "2.1.2599",
+      "resolved": "https://registry.npmjs.org/@tc39/ecma262-biblio/-/ecma262-biblio-2.1.2599.tgz",
+      "integrity": "sha512-e/keyo3Z4SlTQZWoJ9Hn+fduloQLkh5rZHeuN6EDpa+99uODys6QzTXPj5XnkFIhFuor2MHoI2+gCXlLHpfLaw==",
       "dev": true
     },
     "@tootallnate/once": {
@@ -1963,25 +1963,25 @@
       }
     },
     "ecmarkdown": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-7.2.0.tgz",
-      "integrity": "sha512-p0C4SJCvnvtm0y9gPhXBb5DlNbHsNS44ihVKBw3MXviZG2QQpZNH4z/3PbkpgECOjKOeZI+m84ISHVV9WLECFQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-8.1.0.tgz",
+      "integrity": "sha512-dx6cM6RFjzAXkWr2KQRikED4gy70NFQ0vTI4XUQM/LWcjUYRJUbGdd7nd++trXi5az1JSe49TeeCIVMKDXOtcQ==",
       "dev": true,
       "requires": {
         "escape-html": "^1.0.1"
       }
     },
     "ecmarkup": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-15.0.0.tgz",
-      "integrity": "sha512-gKmfqwRqw1uNPwkftEOpVIH3VVV0O99IL2cRmnrBduvTE2szOvDytOk74dIOaAwqmhx/lonQuRZ64G7R2ZCUDQ==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-17.0.2.tgz",
+      "integrity": "sha512-+vvA1tI9sISgCKtnfwdC6dcuLGX4DGHPVy9zPh3XJLHeRxxy8euG1vklMM7gsEb6/J4H0ks2yup5Y/ekU51k6g==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",
         "command-line-usage": "^6.1.1",
         "dedent-js": "^1.0.1",
-        "ecmarkdown": "^7.2.0",
+        "ecmarkdown": "^8.1.0",
         "eslint-formatter-codeframe": "^7.32.1",
         "fast-glob": "^3.2.7",
         "grammarkdown": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "format": "emu-format --write 'spec/*.html'"
   },
   "devDependencies": {
-    "@tc39/ecma262-biblio": "^2.1.2407",
-    "ecmarkup": "^15.0.0"
+    "@tc39/ecma262-biblio": "2.1.2599",
+    "ecmarkup": "^17.0.2"
   },
   "version": "1.0.0",
   "repository": {

--- a/spec/index.html
+++ b/spec/index.html
@@ -308,7 +308,6 @@ markEffects: true
     1. Let _keysIter_ be ? Call(_setRec_.[[Keys]], _setRec_.[[Set]]).
     1. If _keysIter_ is not an Object, throw a *TypeError* exception.
     1. Let _nextMethod_ be ? Get(_keysIter_, *"next"*).
-    1. If IsCallable(_nextMethod_) is *false*, throw a *TypeError* exception.
     1. Return a new Iterator Record { [[Iterator]]: _keysIter_, [[NextMethod]]: _nextMethod_, [[Done]]: *false* }.
   </emu-alg>
 </emu-clause>

--- a/spec/index.html
+++ b/spec/index.html
@@ -14,7 +14,7 @@ markEffects: true
     1. Let _O_ be the *this* value.
     1. Perform ? RequireInternalSlot(_O_, [[SetData]]).
     1. Let _otherRec_ be ? GetSetRecord(_other_).
-    1. Let _keysIter_ be ? GetKeysIterator(_otherRec_).
+    1. Let _keysIter_ be ? GetIteratorFromMethod(_otherRec_.[[Set]], _otherRec_.[[Keys]]).
     1. Let _resultSetData_ be a copy of _O_.[[SetData]].
     1. Let _next_ be *true*.
     1. Repeat, while _next_ is not *false*,
@@ -54,7 +54,7 @@ markEffects: true
           1. NOTE: The number of elements in _O_.[[SetData]] may have increased during execution of _otherRec_.[[Has]].
           1. Set _thisSize_ to the number of elements of _O_.[[SetData]].
     1. Else,
-      1. Let _keysIter_ be ? GetKeysIterator(_otherRec_).
+      1. Let _keysIter_ be ? GetIteratorFromMethod(_otherRec_.[[Set]], _otherRec_.[[Keys]]).
       1. Let _next_ be *true*.
       1. Repeat, while _next_ is not *false*,
         1. Set _next_ to ? IteratorStep(_keysIter_).
@@ -91,7 +91,7 @@ markEffects: true
           1. If _inOther_ is *true*, then
             1. Set _resultSetData_[_index_] to ~empty~.
     1. Else,
-      1. Let _keysIter_ be ? GetKeysIterator(_otherRec_).
+      1. Let _keysIter_ be ? GetIteratorFromMethod(_otherRec_.[[Set]], _otherRec_.[[Keys]]).
       1. Let _next_ be *true*.
       1. Repeat, while _next_ is not *false*,
         1. Set _next_ to ? IteratorStep(_keysIter_).
@@ -113,7 +113,7 @@ markEffects: true
     1. Let _O_ be the *this* value.
     1. Perform ? RequireInternalSlot(_O_, [[SetData]]).
     1. Let _otherRec_ be ? GetSetRecord(_other_).
-    1. Let _keysIter_ be ? GetKeysIterator(_otherRec_).
+    1. Let _keysIter_ be ? GetIteratorFromMethod(_otherRec_.[[Set]], _otherRec_.[[Keys]]).
     1. Let _resultSetData_ be a copy of _O_.[[SetData]].
     1. Let _next_ be *true*.
     1. Repeat, while _next_ is not *false*,
@@ -162,7 +162,7 @@ markEffects: true
     1. Let _otherRec_ be ? GetSetRecord(_other_).
     1. Let _thisSize_ be the number of elements in _O_.[[SetData]].
     1. If _thisSize_ &lt; _otherRec_.[[Size]], return *false*.
-    1. Let _keysIter_ be ? GetKeysIterator(_otherRec_).
+    1. Let _keysIter_ be ? GetIteratorFromMethod(_otherRec_.[[Set]], _otherRec_.[[Keys]]).
     1. Let _next_ be *true*.
     1. Repeat, while _next_ is not *false*,
       1. Set _next_ to ? IteratorStep(_keysIter_).
@@ -194,7 +194,7 @@ markEffects: true
           1. NOTE: The number of elements in _O_.[[SetData]] may have increased during execution of _otherRec_.[[Has]].
           1. Set _thisSize_ to the number of elements of _O_.[[SetData]].
     1. Else,
-      1. Let _keysIter_ be ? GetKeysIterator(_otherRec_).
+      1. Let _keysIter_ be ? GetIteratorFromMethod(_otherRec_.[[Set]], _otherRec_.[[Keys]]).
       1. Let _next_ be *true*.
       1. Repeat, while _next_ is not *false*,
         1. Set _next_ to ? IteratorStep(_keysIter_).
@@ -293,22 +293,6 @@ markEffects: true
     1. Let _keys_ be ? Get(_obj_, *"keys"*).
     1. If IsCallable(_keys_) is *false*, throw a *TypeError* exception.
     1. Return a new Set Record { [[Set]]: _obj_, [[Size]]: _intSize_, [[Has]]: _has_, [[Keys]]: _keys_ }.
-  </emu-alg>
-</emu-clause>
-
-<emu-clause id="sec-getkeysiterator" type="abstract operation">
-  <h1>
-    GetKeysIterator (
-      _setRec_: a Set Record,
-    ): either a normal completion containing an Iterator Record or a throw completion
-  </h1>
-  <dl class="header">
-  </dl>
-  <emu-alg>
-    1. Let _keysIter_ be ? Call(_setRec_.[[Keys]], _setRec_.[[Set]]).
-    1. If _keysIter_ is not an Object, throw a *TypeError* exception.
-    1. Let _nextMethod_ be ? Get(_keysIter_, *"next"*).
-    1. Return a new Iterator Record { [[Iterator]]: _keysIter_, [[NextMethod]]: _nextMethod_, [[Done]]: *false* }.
   </emu-alg>
 </emu-clause>
 


### PR DESCRIPTION
For consistency with [GetIteratorFromMethod](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-getiteratorfrommethod), etc.

Fixes #98.

Since that changes makes GetKeysIterator equivalent to calling GetIteratorFromMethod (added in https://github.com/tc39/ecma262/pull/3021), I've dropped GetKeysIterator and replaced its callsites with calls to GetIteratorFromMethod. That required bumping the biblio, and I bumped ecmarkup while I was at it.